### PR TITLE
docs: update README with improved TOON description and installation i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/toon-format.svg)](https://pypi.org/project/toon-format/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-**Token-Oriented Object Notation** is a compact, human-readable format designed for passing structured data to Large Language Models with significantly reduced token usage.
+**Token-Oriented Object Notation** is a compact, human-readable serialization format designed for passing structured data to Large Language Models with significantly reduced token usage. It's intended for LLM input, not output.
+
+> [!TIP]
+> Think of TOON as a translation layer: use JSON programmatically, convert to TOON for LLM input.
 
 ## Status
 
@@ -13,6 +16,7 @@
 ### Example
 
 **JSON** (verbose):
+
 ```json
 {
   "users": [
@@ -23,10 +27,36 @@
 ```
 
 **TOON** (compact):
-```
+
+```toon
 users[2]{id,name,role}:
   1,Alice,admin
   2,Bob,user
+```
+
+## Installation
+
+Make sure [`uv`](https://github.com/astral-sh/uv?tab=readme-ov-file#installation) is installed. Then install the `toon-format` package:
+
+```shell
+uv pip install toon-format
+# or
+uv add toon-format  # adds to your pyproject.toml
+```
+
+
+## Future Usage
+
+Once implemented, the package will provide:
+
+```python
+from toon_format import encode, decode
+
+data = "id: 123" # your data structure
+toon_string = encode(data)
+decoded = decode(toon_string)
+
+assert data == decoded
 ```
 
 ## Resources
@@ -36,17 +66,6 @@ users[2]{id,name,role}:
 - [Benchmarks & Performance](https://github.com/johannschopplich/toon#benchmarks)
 - [Other Language Implementations](https://github.com/johannschopplich/toon#other-implementations)
 
-## Future Usage
-
-Once implemented, the package will provide:
-
-```python
-from toon_format import encode, decode
-
-data = # your data structure
-toon_string = encode(data)
-decoded = decode(toon_string)
-```
 
 ## Contributing
 


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the purpose and usage of the TOON format, improves onboarding instructions, and reorganizes documentation for better readability. The most important changes include clearer explanations of TOON, a new installation section, improved example formatting, and a more logical structure for resources and usage.

Documentation and explanation improvements:
* Clarified that TOON is a serialization format intended for LLM input, not output, and added a tip comparing TOON to JSON as a translation layer.

Onboarding and installation:
* Added a new "Installation" section with instructions for installing the `toon-format` package using `uv`.

Example formatting:
* Specified the code block language as `toon` for the TOON example to improve syntax highlighting and readability.

Usage and resources organization:
* Updated the usage example to use a string for `data`, added an assertion for round-trip encoding/decoding, and moved the "Resources" section to follow usage instructions for better flow.

Resource links:
* Reformatted resource links as a bullet list for clarity and accessibility.