### PR TITLE
Improve CRLF handling in the decoder

### DIFF
--- a/src/toon_format/_scanner.py
+++ b/src/toon_format/_scanner.py
@@ -211,7 +211,7 @@ def to_parsed_lines(
     # This prevents stray \r characters from appearing in content
     source = source.replace("\r\n", "\n")
 
-    # Strip any remaining standalone \r characters (old Mac format)
+    # Replace any remaining standalone \r characters (old Mac format) with \n
     source = source.replace("\r", "\n")
 
     lines = source.split("\n")

--- a/src/toon_format/_scanner.py
+++ b/src/toon_format/_scanner.py
@@ -207,6 +207,13 @@ def to_parsed_lines(
     if not source.strip():
         return [], []
 
+    # Normalize Windows CRLF line endings to LF
+    # This prevents stray \r characters from appearing in content
+    source = source.replace("\r\n", "\n")
+
+    # Strip any remaining standalone \r characters (old Mac format)
+    source = source.replace("\r", "\n")
+
     lines = source.split("\n")
     parsed: List[ParsedLine] = []
     blank_lines: List[BlankLineInfo] = []

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -140,3 +140,58 @@ b: 4"""
         assert keys == ["z", "a", "m", "b"]
         # Verify order is not alphabetical
         assert keys != ["a", "b", "m", "z"]
+
+
+class TestCRLFDecoding:
+    """Test CRLF (Windows) line ending handling in decoder."""
+
+    def test_decode_object_with_crlf(self):
+        """Test decoding objects with CRLF line endings."""
+        toon = "name: Alice\r\nage: 30\r\n"
+        result = decode(toon)
+        assert result == {"name": "Alice", "age": 30}
+
+    def test_decode_nested_object_with_crlf(self):
+        """Test decoding nested objects with CRLF line endings."""
+        toon = "person:\r\n  name: Alice\r\n  age: 30\r\n"
+        result = decode(toon)
+        assert result == {"person": {"name": "Alice", "age": 30}}
+
+    def test_decode_array_with_crlf(self):
+        """Test decoding arrays with CRLF line endings."""
+        toon = "items[3]:\r\n  - apple\r\n  - banana\r\n  - cherry\r\n"
+        result = decode(toon)
+        assert result == {"items": ["apple", "banana", "cherry"]}
+
+    def test_decode_delimited_array_with_crlf(self):
+        """Test decoding delimited arrays with CRLF line endings."""
+        toon = "items[3]: apple,banana,cherry\r\n"
+        result = decode(toon)
+        assert result == {"items": ["apple", "banana", "cherry"]}
+
+    def test_decode_with_old_mac_cr(self):
+        """Test decoding with old Mac CR line endings."""
+        toon = "name: Alice\rage: 30\r"
+        result = decode(toon)
+        assert result == {"name": "Alice", "age": 30}
+
+    def test_decode_with_mixed_line_endings(self):
+        """Test decoding with mixed line endings."""
+        toon = "name: Alice\r\nage: 30\ncity: NYC\r"
+        result = decode(toon)
+        assert result == {"name": "Alice", "age": 30, "city": "NYC"}
+
+    def test_crlf_does_not_affect_quoted_strings(self):
+        """Test that CRLF normalization doesn't affect escaped \\r in strings."""
+        toon = 'text: "line1\\r\\nline2"\r\n'
+        result = decode(toon)
+        # The string should contain the escaped sequences
+        assert result == {"text": "line1\r\nline2"}
+
+    def test_crlf_in_strict_mode(self):
+        """Test CRLF works correctly in strict mode."""
+        toon = "name:\r\n  first: Alice\r\n  age: 30\r\n"
+        options = DecodeOptions(strict=True)
+        result = decode(toon, options)
+        assert result == {"name": {"first": "Alice", "age": 30}}
+


### PR DESCRIPTION
This pull request improves cross-platform compatibility in the `toon_format` scanner and decoder by normalizing different line endings (Windows CRLF and old Mac CR) to LF, ensuring consistent parsing behavior regardless of the source file's origin. It also adds comprehensive tests to verify correct handling of various line ending scenarios.

**Line ending normalization:**

* Updated `src/toon_format/_scanner.py` to normalize Windows CRLF (`\r\n`) and old Mac CR (`\r`) line endings to LF (`\n`) before parsing, preventing stray carriage return characters from appearing in parsed content.

**Test coverage improvements:**

* Added `TestCRLFDecoding` in `tests/test_decoder.py` to verify that the decoder correctly handles CRLF, CR, mixed line endings, and quoted strings containing escaped `\r` and `\n` sequences, including strict mode decoding.
* Added `TestCRLFHandling` in `tests/test_scanner.py` to ensure the scanner normalizes all types of line endings, preserves indentation, and works correctly in strict mode.