### PR TITLE
feat: Add pathlib.Path normalization to string representation

### DIFF
--- a/src/toon_format/normalize.py
+++ b/src/toon_format/normalize.py
@@ -6,7 +6,6 @@ Converts Python-specific types to JSON-compatible values before encoding:
 - datetime/date → ISO 8601 strings
 - Decimal → float
 - tuple/set/frozenset → sorted lists
-- bytes/bytearray → base64 encoded strings
 - pathlib.Path → string representation
 - Infinity/NaN → null
 - Functions/callables → null
@@ -18,7 +17,7 @@ import sys
 from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Any
 
 # TypeGuard was added in Python 3.10, use typing_extensions for older versions
@@ -76,7 +75,6 @@ def normalize_value(value: Any) -> JsonValue:
         - Recursive: normalizes nested structures
         - Sets are sorted for deterministic output
         - Heterogeneous sets sorted by repr() if natural sorting fails
-        - bytes/bytearray are base64 encoded
         - Path objects are converted to their string representation
     """
     if value is None:

--- a/src/toon_format/normalize.py
+++ b/src/toon_format/normalize.py
@@ -6,6 +6,8 @@ Converts Python-specific types to JSON-compatible values before encoding:
 - datetime/date → ISO 8601 strings
 - Decimal → float
 - tuple/set/frozenset → sorted lists
+- bytes/bytearray → base64 encoded strings
+- pathlib.Path → string representation
 - Infinity/NaN → null
 - Functions/callables → null
 - Negative zero → zero
@@ -16,6 +18,7 @@ import sys
 from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
+from pathlib import Path, PurePath
 from typing import Any
 
 # TypeGuard was added in Python 3.10, use typing_extensions for older versions
@@ -39,6 +42,7 @@ def normalize_value(value: Any) -> JsonValue:
     Converts Python-specific types to JSON-compatible equivalents:
     - datetime objects → ISO 8601 strings
     - sets → sorted lists
+    - pathlib.Path → string representation
     - Large integers (>2^53-1) → strings (for JS compatibility)
     - Non-finite floats (inf, -inf, NaN) → null
     - Negative zero → positive zero
@@ -64,10 +68,16 @@ def normalize_value(value: Any) -> JsonValue:
         >>> normalize_value(2**60)  # Large integer
         '1152921504606846976'
 
+        >>> from pathlib import Path
+        >>> normalize_value(Path('/tmp/file.txt'))
+        '/tmp/file.txt'
+
     Note:
         - Recursive: normalizes nested structures
         - Sets are sorted for deterministic output
         - Heterogeneous sets sorted by repr() if natural sorting fails
+        - bytes/bytearray are base64 encoded
+        - Path objects are converted to their string representation
     """
     if value is None:
         return None
@@ -99,6 +109,11 @@ def normalize_value(value: Any) -> JsonValue:
             logger.debug(f"Converting non-finite Decimal to null: {value}")
             return None
         return float(value)
+
+    # Handle pathlib.Path objects -> string representation
+    if isinstance(value, PurePath):
+        logger.debug(f"Converting {type(value).__name__} to string: {value}")
+        return str(value)
 
     if isinstance(value, datetime):
         try:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -455,8 +455,6 @@ class TestPathNormalization:
 
     def test_path_in_array(self):
         """Path objects in arrays should be normalized."""
-        from pathlib import Path
-
         data = {"paths": [Path("/tmp/a"), Path("/tmp/b"), Path("/tmp/c")]}
         result = encode(data)
         decoded = decode(result)
@@ -465,8 +463,6 @@ class TestPathNormalization:
 
     def test_path_in_nested_structure(self):
         """Path objects in nested structures should be normalized."""
-        from pathlib import Path
-
         data = {
             "project": {
                 "root": Path("/home/user/project"),


### PR DESCRIPTION
## Description

Added support for normalizing common Python types (`pathlib.Path` objects) to JSON-compatible values during TOON encoding. This enhancement makes it easier to serialize Python applications that work with file paths.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test coverage improvement

## Related Issues

Closes # (if applicable)

## Changes Made

- **Extended `normalize_value()` function** in `src/toon_format/normalize.py`:
  - Added `pathlib.Path`, `PurePath`, `PurePosixPath`, `PureWindowsPath` → string conversion
  - Updated module docstring to document new type conversions
  - Added detailed examples in function docstring

- **Added comprehensive test coverage** in `tests/test_normalization.py`:
  - `TestPathNormalization` class with 5 tests covering Path object handling

## SPEC Compliance

- [x] This PR implements/fixes spec compliance
- Spec section(s) affected: Section 3 (Normalization) - extends Python-specific normalization
- Spec version: v1.5 (maintains compatibility while extending Python support)

## Testing

- [x] All existing tests pass
- [x] Added new tests for changes
- [x] Tested on Python 3.8
- [x] Tested on Python 3.9
- [x] Tested on Python 3.10
- [x] Tested on Python 3.11
- [x] Tested on Python 3.12

### Test Output

```bash
$ pytest tests/test_normalization.py::TestPathNormalization -v
======================== test session starts =========================
collected 5 tests

tests/test_normalization.py::TestPathNormalization::test_path_to_string PASSED
tests/test_normalization.py::TestPathNormalization::test_relative_path PASSED
tests/test_normalization.py::TestPathNormalization::test_pure_path PASSED
tests/test_normalization.py::TestPathNormalization::test_path_in_array PASSED
tests/test_normalization.py::TestPathNormalization::test_path_in_nested_structure PASSED

$ pytest tests/ -v
======================== 818 passed, 13 skipped in 2.34s =========================