### PR TITLE
fix: Refined encoding logic for array of nested objects

### DIFF
--- a/src/toon_format/encoders.py
+++ b/src/toon_format/encoders.py
@@ -447,9 +447,9 @@ def encode_object_as_list_item(
             # Now encode the array content at depth + 1
             encode_array_content(first_arr, options, writer, depth + 1)
     else:
-        # If first value is an object, put "-" alone then encode normally
-        writer.push(depth, LIST_ITEM_PREFIX.rstrip())
-        encode_key_value_pair(first_key, first_value, options, writer, depth + 1)
+        # If first value is an object, put "- key:" then content at depth + 2
+        writer.push(depth, f"{LIST_ITEM_PREFIX}{first_key}:")
+        encode_value(first_value, options, writer, depth + 2)
 
     # Rest of the keys go normally indented
     for key, value in keys[1:]:

--- a/tests/fixtures/encode/arrays-nested.json
+++ b/tests/fixtures/encode/arrays-nested.json
@@ -94,6 +94,14 @@
       },
       "expected": "items[2]:\n  - a: 1\n  - [2]: 1,2",
       "specSection": "7.3"
+    },
+    {
+      "name": "encodes array of nested objects",
+      "input": {
+        "items": [{ "a": { "b": 1 }}, { "c": 2 }]
+      },
+      "expected": "items[2]:\n  - a:\n      b: 1\n  - c: 2",
+      "specSection": "10"
     }
   ]
 }


### PR DESCRIPTION
## Description

This PR fixes the encoding logic for array of nested objects. The current implementation encodes the JSON `[{"a": {"b": "123"}}]` as
```
[1]:
  -
    a:
      b: "123"
```
The change fixes this to be encoded as
```
[1]:
  - a:
      b: "123"
```
I have refined the logic for encoding object as list item to put the first key in a nested object on same line with "-" and continue encoding its corresponding value further according to `SPEC.md`. The decoding logic already looks good and needed change. This PR also adds a test case to validate the case.

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #33 

## Changes Made

<!-- List the main changes in this PR -->

- Put the first key of nested object on the same line with "-", when encoding it as list item.
- Added a test case to validate encoding array of nested object(s).

## SPEC Compliance

<!-- If this PR relates to the TOON spec, indicate which sections are affected -->

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
  - 10
- [ ] Spec version: 2.0

## Testing

<!-- Describe the tests you added or ran -->

- [x] All existing tests pass
- [x] Added new tests for changes
- [ ] Tested on Python 3.8
- [ ] Tested on Python 3.9
- [ ] Tested on Python 3.10
- [ ] Tested on Python 3.11
- [ ] Tested on Python 3.12
- [x] Tested on Python 3.13
- [x] Tested on Python 3.14

### Test Output

```bash
==================================================== tests coverage ===================================================== 
____________________________________ coverage: platform win32, python 3.14.0-final-0 ____________________________________ 

Name                                Stmts   Miss   Cover   Missing
------------------------------------------------------------------
src\toon_format\__init__.py             6      0 100.00%
src\toon_format\__main__.py             4      4   0.00%   8-13
src\toon_format\_literal_utils.py      13      1  92.31%   58
src\toon_format\_parsing_utils.py      44      0 100.00%
src\toon_format\_scanner.py            80      0 100.00%
src\toon_format\_string_utils.py       60      0 100.00%
src\toon_format\_validation.py         29      0 100.00%
src\toon_format\cli.py                 77      1  98.70%   217
src\toon_format\constants.py           30      0 100.00%
src\toon_format\decoder.py            338     28  91.72%   98-99, 135, 156-157, 172, 183, 204, 364-365, 412-414, 529, 539,src\toon_format\encoder.py             21      1  95.24%   54
src\toon_format\logging_config.py      31      8  74.19%   83-92
src\toon_format\normalize.py           92      5  94.57%   25, 108-109, 116-117
src\toon_format\types.py               18      0 100.00%
src\toon_format\utils.py               37     25  32.43%   44-48, 61-62, 85-91, 120-131, 166-187
src\toon_format\writer.py              18      0 100.00%
------------------------------------------------------------------
================================================ short test summary info ================================================ 
============================================ 794 passed, 13 skipped in 5.66s ============================================
```

## Code Quality

<!-- Confirm code quality checks -->

- [x] Ran `ruff check src/toon_format tests` - no issues
- [x] Ran `ruff format src/toon_format tests` - code formatted
- [x] Ran `mypy src/toon_format` - no critical errors
- [x] All tests pass: `pytest tests/ -v`

## Checklist

<!-- Mark completed items with an [x] -->

- [x] My code follows the project's coding standards (PEP 8, line length 100)
- [x] I have added type hints to new code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation (README.md, CLAUDE.md if needed)
- [x] My changes do not introduce new dependencies
- [x] I have maintained Python 3.8+ compatibility
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Performance Impact

<!-- If applicable, describe any performance implications -->

- [x] No performance impact
- [ ] Performance improvement (describe below)
- [ ] Potential performance regression (describe and justify below)

<!-- Details: -->

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Checklist for Reviewers

<!-- For maintainers reviewing this PR -->

- [ ] Code changes are clear and well-documented
- [ ] Tests adequately cover the changes
- [ ] Documentation is updated
- [ ] No security concerns
- [ ] Follows TOON specification
- [ ] Backward compatible (or breaking changes are justified and documented)
