### PR TITLE
feat(cli): add --stats flag for token comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ echo '{"x": 1}' | toon -            # Stdin/stdout
 # Options
 toon data.json --encode --delimiter "\t" --length-marker
 toon data.toon --decode --no-strict --indent 4
+toon data.json --stats 
 ```
 
-**Options:** `-e/--encode` `-d/--decode` `-o/--output` `--delimiter` `--indent` `--length-marker` `--no-strict`
+**Options:** `-e/--encode` `-d/--decode` `-o/--output` `--delimiter` `--indent` `--length-marker` `--no-strict` `--stats`
 
 ## API Reference
 


### PR DESCRIPTION
## Description
Adds `--stats` flag to the CLI for displaying token count statistics when encoding JSON to TOON. Uses the existing `compare_formats()` utility from `utils.py` to show a comparison table with token counts and savings percentage.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
Closes #

## Changes Made
- Added `--stats` argument to CLI argparse configuration
- Integrated existing `compare_formats()` function from utils.py
- Added error handling for missing tiktoken with helpful installation message
- Added comprehensive test coverage in `test_cli.py`
- Updated README.md to document the new `--stats` flag

## SPEC Compliance
- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing
- [x] All existing tests pass
- [x] Added new tests for changes
- [ ] Tested on Python 3.8
- [ ] Tested on Python 3.9
- [ ] Tested on Python 3.10
- [x] Tested on Python 3.11
- [ ] Tested on Python 3.12

### Test Output
799 passed, 13 skipped in 3.85s
TOTAL      1123     76  93.23%
Coverage : 93.23%


## Code Quality
- [x] Ran `ruff check src/toon_format tests` - no issues
- [x] Ran `ruff format src/toon_format tests` - code formatted
- [x] Ran `mypy src/toon_format` - no critical errors
- [x] All tests pass: `pytest tests/ -v`

## Checklist
- [x] My code follows the project's coding standards (PEP 8, line length 100)
- [x] I have added type hints to new code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation (README.md, CLAUDE.md if needed)
- [x] My changes do not introduce new dependencies
- [x] I have maintained Python 3.8+ compatibility
- [x] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Performance Impact
- [x] No performance impact
- [ ] Performance improvement (describe below)
- [ ] Potential performance regression (describe and justify below)

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

## Screenshots / Examples
```bash
$ echo '{"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}' | uv run toon - --stats
```

Output:
```
Format Comparison
────────────────────────────────────────────────
Format      Tokens    Size (chars)
JSON           45            117
TOON           19             36
────────────────────────────────────────────────
Savings: 26 tokens (57.8%)
users[2]{id,name}:
  1,Alice
  2,Bob

```

## Additional Context
This is my first contribution to toon-python. The feature leverages existing token counting utilities from `utils.py` that were already part of the public API but not exposed in the CLI. No new dependencies required - uses existing `tiktoken` from the `benchmark` dependency group.

## Checklist for Reviewers
- [ ] Code changes are clear and well-documented
- [ ] Tests adequately cover the changes
- [ ] Documentation is updated
- [ ] No security concerns
- [ ] Follows TOON specification
- [ ] Backward compatible (or breaking changes are justified and documented)