### PR TITLE
feat: deduplicate version and bump to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toon_format"
-version = "0.9.0-beta.1"
+dynamic = ["version"]
 description = "A compact, human-readable serialization format designed for passing structured data to Large Language Models with significantly reduced token usage"
 readme = "README.md"
 authors = [
@@ -43,7 +43,11 @@ dev = [
     "pytest-cov>=4.1.0",
     "ruff>=0.8.0",
     "mypy>=1.8.0",
+    "build",
 ]
+
+[tool.hatch.version]
+path = "src/toon_format/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/toon_format/__init__.py
+++ b/src/toon_format/__init__.py
@@ -25,7 +25,7 @@ from .encoder import encode
 from .types import DecodeOptions, Delimiter, DelimiterKey, EncodeOptions
 from .utils import compare_formats, count_tokens, estimate_savings
 
-__version__ = "0.9.0-beta.1"
+__version__ = "0.9.1"
 __all__ = [
     "encode",
     "decode",


### PR DESCRIPTION
## Description

Change versioning according to https://hatch.pypa.io/1.9/version/ and bump version to 0.9.1
