### PR TITLE
fix(decoder): reject negative array lengths in parse_header

### DIFF
--- a/src/toon_format/decoder.py
+++ b/src/toon_format/decoder.py
@@ -156,10 +156,13 @@ def parse_header(
         delimiter = COMMA
         length_str = bracket_content[:-1]
 
-    # Parse length
+    # Parse length - reject non-integer strings (negative values are invalid)
     try:
         length = int(length_str)
     except ValueError:
+        return None
+
+    if length < 0:
         return None
 
     # Check for fields segment


### PR DESCRIPTION
## Summary

- `parse_header()` uses `int(length_str)` to parse the bracket segment length, but has no guard against negative values. `int("-5")` succeeds in Python and returns `-5`, so a document declaring `arr[-1]:` would be silently accepted. Downstream consumers receive a negative `expected_length`, which either produces a silent no-op or a confusing strict-mode length-mismatch error rather than a clear parse failure at the header level.
- Fix: add `if length < 0: return None` immediately after the `int()` conversion, matching the behaviour of the TypeScript reference implementation (fixed in toon-format/toon#302).

## Test results

817 passed, 13 skipped (all skips are pre-existing normalization roundtrip exclusions).

## Related

A second bug exists in `parse_delimited_values` in `_parsing_utils.py`: a trailing delimiter (e.g. `a,b,`) produces a spurious empty final element. The fix for that interacts with edge-case expectations for empty input (`""` → `[]`) and lone-delimiter input (`","` → `["", ""]`) that are not covered by the current spec fixtures. That will be tracked separately as an issue once the expected behaviour for those cases is confirmed against the spec.

Companion fix to toon-format/toon#302 (TypeScript reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)